### PR TITLE
Wrap the name retrieval of pEnv.ref with try-catch

### DIFF
--- a/lib/ailia_model.dart
+++ b/lib/ailia_model.dart
@@ -371,10 +371,16 @@ class AiliaModel {
       Pointer<ailia_dart.AILIAEnvironment> pEnv = ppEnv.value;
       malloc.free(ppEnv);
       AiliaEnvironment env = AiliaEnvironment();
-      env.id = pEnv.ref.id;
-      env.name = pEnv.ref.name.cast<Utf8>().toDartString();
-      env.props = pEnv.ref.props;
-      envList.add(env);
+      try {
+        env.id = pEnv.ref.id;
+        env.props = pEnv.ref.props;
+        env.name = pEnv.ref.name
+            .cast<Utf8>()
+            .toDartString(); // This always fails one time in this loop
+        envList.add(env);
+      } catch (error) {
+        print("ailiaGetEnvironment failed $error");
+      }
     }
     malloc.free(count);
     return envList;


### PR DESCRIPTION
```dart
        env.name = pEnv.ref.name
            .cast<Utf8>()
            .toDartString(); // This always fails one time in this loop
```

I can't inspect the function code(`getEnvironmentList`) called by ffi, only thing I could check is symbols are registered from ./libailia.dylib binary file.

not sure why ref.name is failing on conversion to dart's string type.

env
```
❯ flutter --version                            
Flutter 3.22.2 • channel stable • https://github.com/flutter/flutter.git
Framework • revision 761747bfc5 (4 weeks ago) • 2024-06-05 22:15:13 +0200
Engine • revision edd8546116
Tools • Dart 3.4.3 • DevTools 2.34.3

OS: macos, 14.3.1 (23D60)
```