### PR TITLE
Unit test support

### DIFF
--- a/lib/ailia_model.dart
+++ b/lib/ailia_model.dart
@@ -46,6 +46,17 @@ class AiliaModel {
   bool _available = false;
 
   static String _ailiaCommonGetPath() {
+    if (Platform.environment.containsKey('FLUTTER_TEST')) {
+      if (Platform.isMacOS) {
+        return 'macos/libailia.dylib';
+      }
+      if (Platform.isLinux) {
+        return 'linux/x64/libailia.so';
+      }
+      if (Platform.isWindows) {
+        return 'windows/x64/ailia.dll';
+      }
+    }
     if (Platform.isAndroid || Platform.isLinux) {
       return 'libailia.so';
     }


### PR DESCRIPTION
Unit testから実行した場合にdylibのLoadLibraryに失敗する問題への対策です。Unit testから呼び出されている場合に、ルートからのパスでdylibを読み込みます。
https://github.com/dart-archive/ffi/issues/39